### PR TITLE
Without this, the .deb is built but installing it does not result in …

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -97,6 +97,10 @@ ospackage {
   from "${project.buildDir}/install/${project.applicationName}"
 }
 
+buildDeb {
+  dependsOn installApp
+}
+
 ideaConfig {
   codeStyleXml = file('idea/codeStyle.xml')
 }


### PR DESCRIPTION
…rush begin installed in /opt/rush.
@skim1420 please review.
Have verified locally.
We'll kick off the new build immediately after merging to verify jenkins job is back in working order.
