### PR TITLE
Renaming rush to rrush.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,7 +81,7 @@ startScripts {
   }
 }
 
-applicationName = 'rush'
+applicationName = 'rrush'
 applicationDefaultJvmArgs = ["-Djava.security.egd=file:/dev/./urandom", "-Dspring.config.location=/opt/spinnaker/config/"]
 applicationDistribution.from(project.file('src/main/resources')) {
   into "config"


### PR DESCRIPTION
There is already a service installed on debian/ubuntu named rush.
Also considered mush.
