### PR TITLE
Set HOME to /home/spinnaker for upstart.

### DIFF
--- a/etc/init/rush.conf
+++ b/etc/init/rush.conf
@@ -7,4 +7,5 @@ expect fork
 
 stop on stopping spinnaker
 
+env HOME=/home/spinnaker
 exec /opt/rush/bin/rush 2>&1 > /var/log/spinnaker/rush/rush.log &


### PR DESCRIPTION
Otherwise, the aws libs can't find ~/.aws/credentials.
@dstengle Thanks!
