### PR TITLE
Update ScriptExecutorLocal.startScript() to wait a moment and to then…

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/rush/local/scripts/ScriptExecutorLocal.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/rush/local/scripts/ScriptExecutorLocal.groovy
@@ -114,6 +114,12 @@ class ScriptExecutorLocal implements ScriptExecutor {
             stdOutAndErr: stdOutAndErr
           ])
           executionRepo.updateStatus(executionId, ScriptExecutionStatus.RUNNING)
+
+          // Give the execution some time to spin up.
+          sleep(500)
+
+          // Update the status right away so we can fail fast if necessary.
+          updateExecution(executionId)
         }
       }
     )


### PR DESCRIPTION
… update the execution status right away instead of waiting for the next polling interval.