### PR TITLE
LIMIT 1 on cassandra test query

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/rush/scripts/ScriptExecutionRepo.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/rush/scripts/ScriptExecutionRepo.groovy
@@ -48,7 +48,7 @@ class ScriptExecutionRepo implements ApplicationListener<ContextRefreshedEvent> 
     CF_EXECUTIONS = ColumnFamily.newColumnFamily(CF_NAME, IntegerSerializer.get(), StringSerializer.get())
 
     try {
-      runQuery '''select * from execution;'''
+      runQuery '''SELECT * FROM execution LIMIT 1;'''
     } catch (BadRequestException ignored) {
       runQuery '''\
                 CREATE TABLE execution(


### PR DESCRIPTION
The test query does not need to fetch all the rows in this table in order to see if the table is present or not.