### PR TITLE
Write RUNNING state to cassandra before adding build to local build c…

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/rush/local/scripts/ScriptExecutorLocal.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/rush/local/scripts/ScriptExecutorLocal.groovy
@@ -108,15 +108,16 @@ class ScriptExecutorLocal implements ScriptExecutor {
           executor.setWatchdog(watchdog)
           executor.execute(commandLine, resultHandler)
 
+          // Give the execution some time to spin up.
+          sleep(500)
+
+          executionRepo.updateStatus(executionId, ScriptExecutionStatus.RUNNING)
+
           executionIdToHandlerMap.put(executionId, [
             handler: resultHandler,
             watchdog: watchdog,
             stdOutAndErr: stdOutAndErr
           ])
-          executionRepo.updateStatus(executionId, ScriptExecutionStatus.RUNNING)
-
-          // Give the execution some time to spin up.
-          sleep(500)
 
           // Update the status right away so we can fail fast if necessary.
           updateExecution(executionId)


### PR DESCRIPTION
…ache. This keeps the ScriptExecutionPoller from killing the execution to early

This is so that this code that might run whenever does not cancel the job before RUNNING state is propagated to cassandra https://github.com/spinnaker/rush/blob/master/src/main/groovy/com/netflix/spinnaker/rush/scripts/ScriptExecutionPoller.groovy#L79

This has stabilised our chroot builds. We are running with a cassandra cluster with 3 nodes instead of single instance cassandra. Our tests shows that single instance cassandra is not affected by this bug.