### PR TITLE
On finished job, sync local cache before updating cassandra. 

### DIFF
--- a/src/main/groovy/com/netflix/spinnaker/rush/local/scripts/ScriptExecutorLocal.groovy
+++ b/src/main/groovy/com/netflix/spinnaker/rush/local/scripts/ScriptExecutorLocal.groovy
@@ -176,8 +176,8 @@ class ScriptExecutorLocal implements ScriptExecutor {
 
         executionStatus = resultHandler.exitValue == 0 ? ScriptExecutionStatus.SUCCESSFUL : ScriptExecutionStatus.FAILED
 
-        executionRepo.updateStatus(executionId, executionStatus)
         executionIdToHandlerMap.remove(executionId)
+        executionRepo.updateStatus(executionId, executionStatus)
       } else {
         executionStatus = ScriptExecutionStatus.RUNNING
       }


### PR DESCRIPTION
Avoid synchronizeCanceledExecutions marking successful jobs as CANCELED

This is to update the local job cache before marking the job as done in cassandra. We have seen this in our logs:
```
2016-01-29 08:04:07.310  INFO 1791 --- [readScheduler-1] c.n.s.r.l.scripts.ScriptExecutorLocal    : Polling state for cc85b100-c65d-11e5-a8c7-06c6d65e4175...
2016-01-29 08:04:07.311  INFO 1791 --- [readScheduler-1] c.n.s.r.l.scripts.ScriptExecutorLocal    : State for cc85b100-c65d-11e5-a8c7-06c6d65e4175 changed with exit code 0.
2016-01-29 08:04:07.406  INFO 1791 --- [readScheduler-2] c.n.s.r.l.scripts.ScriptExecutorLocal    : Execution cc85b100-c65d-11e5-a8c7-06c6d65e4175 must have been cancelled by something other than this rush instance.
2016-01-29 08:04:07.406  INFO 1791 --- [readScheduler-2] c.n.s.r.l.scripts.ScriptExecutorLocal    : Canceling execution cc85b100-c65d-11e5-a8c7-06c6d65e4175...
```