### PR TITLE
auto start rush service when deployed standalone, fix issue #762

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -131,6 +131,13 @@ ospackage {
     fileType = CONFIG | NOREPLACE
   }
 
+  from(file('etc/init/rush-trigger.conf')) {
+    into('/etc/init')
+    user = 'root'
+    permissionGroup = 'root'
+    fileType = CONFIG | NOREPLACE
+  }
+
   from(file('etc/logrotate.d/rush')) {
     into('/etc/logrotate.d')
     user = 'root'

--- a/etc/init/rush-trigger.conf
+++ b/etc/init/rush-trigger.conf
@@ -1,0 +1,13 @@
+start on filesystem or runlevel [2345]
+
+script
+  set +e
+  status spinnaker
+  SPINNAKER_EXISTS_CHECK="$(echo $?)"
+  set -e
+  if [ $SPINNAKER_EXISTS_CHECK != 0 ]
+  then
+    initctl emit rush_triggered
+    exit 0
+  fi
+end script

--- a/etc/init/rush.conf
+++ b/etc/init/rush.conf
@@ -1,5 +1,7 @@
 description "rush"
 
+start on rush_triggered
+
 setuid spinnaker
 setgid spinnaker
 


### PR DESCRIPTION
this only includes changes for rush service, though other services have the same issue and need be addressed as well.
we would like to get feed back on if we are on the right trace to address the issue.