### PR TITLE
auto start rush service if rush is installed standalone, issue #762

### DIFF
--- a/etc/init/rush.conf
+++ b/etc/init/rush.conf
@@ -1,5 +1,7 @@
 description "rush"
 
+start on filesystem or runlevel [2345]
+
 setuid spinnaker
 setgid spinnaker
 


### PR DESCRIPTION
@dpeterka, @ewiseblatt
Taking comments by @dpeterka and simplied checking for standalone install.
Created a new file rush-standalone.conf, it starts rush when install is standalone.
No change is made to existing file rush.conf

We still could not find a way to make it work both ways without creating a new file.
If you have a way to do it, let us know.
