### PR TITLE
Set os to LINUX to make RPMs installable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -138,6 +138,7 @@ ospackage {
     fileType = CONFIG | NOREPLACE
   }
 
+  os = LINUX
 }
 
 buildDeb {


### PR DESCRIPTION
Without the option, RPM complains it doesn't know the OS. This
option is set in the rest of the Spinnaker subprojects.